### PR TITLE
Fix NVLink bandwidth on both backends (#10)

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -102,8 +102,7 @@ pick a custom set.
   compute process are included. If no processes are found, only the header is
   output and a diagnostic message is printed to stderr.
 - **Rate fields**: `pcie_replay_rate_s` requires two samples to compute a
-  rate, so it will be empty on the first row. `nvlink_gbps` is an
-  instantaneous reading and is available immediately.
+  rate, so it will be empty on the first row.
 - **Missing values**: Exported as empty strings in the CSV.
 - **Pipe-friendly**: Output is flushed after each poll interval. Handles
   `BrokenPipeError` gracefully (e.g. `kempnerpulse --export | head -20`).

--- a/docs/export.md
+++ b/docs/export.md
@@ -101,8 +101,9 @@ pick a custom set.
 - **GPU filtering**: Only GPUs where the current user has at least one running
   compute process are included. If no processes are found, only the header is
   output and a diagnostic message is printed to stderr.
-- **Rate fields**: `nvlink_gbps` and `pcie_replay_rate_s` require two samples
-  to compute a rate, so they will be empty on the first row.
+- **Rate fields**: `pcie_replay_rate_s` requires two samples to compute a
+  rate, so it will be empty on the first row. `nvlink_gbps` is an
+  instantaneous reading and is available immediately.
 - **Missing values**: Exported as empty strings in the CSV.
 - **Pipe-friendly**: Output is flushed after each poll interval. Handles
   `BrokenPipeError` gracefully (e.g. `kempnerpulse --export | head -20`).

--- a/kempner_pulse.py
+++ b/kempner_pulse.py
@@ -781,10 +781,12 @@ class DcgmStreamReader:
         self._skipped_first: bool = False
         self._error: Optional[BaseException] = None
         self._started = False
-        # dcgmi dmon reports field 449 (NVLINK_BANDWIDTH_TOTAL) as per-interval
-        # values, not as a cumulative counter (unlike fields 156 and 202 which
-        # ARE cumulative). Accumulate into a running total so downstream rate()
-        # sees a monotonically growing counter and computes bytes/s correctly.
+        # dcgmi dmon reports field 449 (NVLINK_BANDWIDTH_TOTAL) as an
+        # instantaneous rate in MB/s (header: "MB/"), unlike fields 156 and 202
+        # which are cumulative counters. We convert each tick's MB/s reading
+        # into bytes-transferred-this-interval and accumulate into a monotonic
+        # counter so downstream rate() produces bytes/s and
+        # bytes_per_s_to_gbps() converts correctly.
         self._nvlink_accum: Dict[str, float] = {}
 
     # ── lifecycle ───────────────────────────────────────────────────────
@@ -953,12 +955,14 @@ class DcgmStreamReader:
         # Reassemble block text in original order, then parse once
         block_text = "\n".join(current[gid] for gid in order)
         sample = parse_dcgm_dmon(block_text, self._gpu_models)
-        # Accumulate NVLINK_BANDWIDTH_TOTAL per-interval values into a running
-        # total so rate() sees a monotonic counter (see __init__ comment).
+        # Convert NVLINK_BANDWIDTH_TOTAL from MB/s rate into a cumulative
+        # bytes counter so downstream rate() produces bytes/s correctly.
+        interval_s = self._poll_ms / 1000.0
         for gpu_id, metrics in sample.metrics.items():
-            raw = metrics.get(NVLINK_TOTAL_METRIC)
-            if raw is not None:
-                self._nvlink_accum[gpu_id] = self._nvlink_accum.get(gpu_id, 0.0) + raw
+            raw_mbps = metrics.get(NVLINK_TOTAL_METRIC)
+            if raw_mbps is not None:
+                bytes_this_tick = raw_mbps * 1e6 * interval_s
+                self._nvlink_accum[gpu_id] = self._nvlink_accum.get(gpu_id, 0.0) + bytes_this_tick
                 metrics[NVLINK_TOTAL_METRIC] = self._nvlink_accum[gpu_id]
         if not self._skipped_first:
             # Drop the first tick — profiling fields often N/A on cold dcgmi start

--- a/kempner_pulse.py
+++ b/kempner_pulse.py
@@ -63,7 +63,6 @@ RATIO_0_1 = {
 COUNTER_METRICS = {
     "DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION",
     "DCGM_FI_DEV_PCIE_REPLAY_COUNTER",
-    "DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL",
 }
 
 NVLINK_TOTAL_METRIC = "DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL"
@@ -85,7 +84,7 @@ DCGM_DMON_FIELDS: Tuple[Tuple[int, str], ...] = (
     (251,  "DCGM_FI_DEV_FB_FREE"),                 # MiB
     (252,  "DCGM_FI_DEV_FB_USED"),                 # MiB
     (253,  "DCGM_FI_DEV_FB_RESERVED"),             # MiB
-    (449,  "DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL"),  # bytes (counter)
+    (449,  "DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL"),  # MB/s (gauge, despite dcgm-exporter labelling it counter)
     # Profiling metrics (ratio 0-1)
     (1001, "DCGM_FI_PROF_GR_ENGINE_ACTIVE"),
     (1002, "DCGM_FI_PROF_SM_ACTIVE"),
@@ -781,13 +780,6 @@ class DcgmStreamReader:
         self._skipped_first: bool = False
         self._error: Optional[BaseException] = None
         self._started = False
-        # dcgmi dmon reports field 449 (NVLINK_BANDWIDTH_TOTAL) as an
-        # instantaneous rate in MB/s (header: "MB/"), unlike fields 156 and 202
-        # which are cumulative counters. We convert each tick's MB/s reading
-        # into bytes-transferred-this-interval and accumulate into a monotonic
-        # counter so downstream rate() produces bytes/s and
-        # bytes_per_s_to_gbps() converts correctly.
-        self._nvlink_accum: Dict[str, float] = {}
 
     # ── lifecycle ───────────────────────────────────────────────────────
 
@@ -955,15 +947,6 @@ class DcgmStreamReader:
         # Reassemble block text in original order, then parse once
         block_text = "\n".join(current[gid] for gid in order)
         sample = parse_dcgm_dmon(block_text, self._gpu_models)
-        # Convert NVLINK_BANDWIDTH_TOTAL from MB/s rate into a cumulative
-        # bytes counter so downstream rate() produces bytes/s correctly.
-        interval_s = self._poll_ms / 1000.0
-        for gpu_id, metrics in sample.metrics.items():
-            raw_mbps = metrics.get(NVLINK_TOTAL_METRIC)
-            if raw_mbps is not None:
-                bytes_this_tick = raw_mbps * 1e6 * interval_s
-                self._nvlink_accum[gpu_id] = self._nvlink_accum.get(gpu_id, 0.0) + bytes_this_tick
-                metrics[NVLINK_TOTAL_METRIC] = self._nvlink_accum[gpu_id]
         if not self._skipped_first:
             # Drop the first tick — profiling fields often N/A on cold dcgmi start
             self._skipped_first = True
@@ -1349,6 +1332,17 @@ def bytes_per_s_to_gbps(v: Optional[float]) -> Optional[float]:
     return float(v) / 1e9
 
 
+def nvlink_to_gbps(v: Optional[float]) -> Optional[float]:
+    """Convert DCGM field 449 value (MB/s) to GB/s.
+
+    Both dcgmi dmon and dcgm-exporter report DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL
+    as an instantaneous rate in MB/s (not a cumulative counter).
+    """
+    if v is None:
+        return None
+    return float(v) / 1e3
+
+
 def fmt_gbps(v: Optional[float], digits: int = 2) -> str:
     if v is None or math.isnan(v):
         return "--"
@@ -1661,7 +1655,7 @@ def update_history(history: HistoryStore, states: List[DerivedGPUState]) -> None
             history.push(s.gpu_id, "pcie_tx", pcie_tx)
         if pcie_rx is not None and pcie_tx is not None:
             history.push(s.gpu_id, "pcie_rxtx", pcie_rx + pcie_tx)
-        nvlink_gbps = bytes_per_s_to_gbps(s.rates.get(NVLINK_TOTAL_METRIC))
+        nvlink_gbps = nvlink_to_gbps(s.values.get(NVLINK_TOTAL_METRIC))
         if nvlink_gbps is not None:
             history.push(s.gpu_id, "nvlink_gbps", nvlink_gbps)
         fp64 = to_percent("DCGM_FI_PROF_PIPE_FP64_ACTIVE", s.values.get("DCGM_FI_PROF_PIPE_FP64_ACTIVE"))
@@ -1740,7 +1734,7 @@ def export_gpu_row(state: DerivedGPUState, timestamp: float,
         elif key == "_mem_used_pct":
             row.append(f"{state.memory_used_pct:.2f}" if state.memory_used_pct is not None else "")
         elif key == "_nvlink_gbps":
-            gbps = bytes_per_s_to_gbps(state.rates.get(NVLINK_TOTAL_METRIC))
+            gbps = nvlink_to_gbps(state.values.get(NVLINK_TOTAL_METRIC))
             row.append(f"{gbps:.4f}" if gbps is not None else "")
         elif key == "_pcie_replay_rate":
             rr = state.rates.get("DCGM_FI_DEV_PCIE_REPLAY_COUNTER")
@@ -1957,7 +1951,7 @@ def gpu_card(state: DerivedGPUState, history: HistoryStore, power_limit: Optiona
     right.add_column(justify="left", min_width=11, no_wrap=True)
     right.add_column(justify="right", min_width=22, no_wrap=True)
     memcpy_pct = to_percent("DCGM_FI_DEV_MEM_COPY_UTIL", state.values.get("DCGM_FI_DEV_MEM_COPY_UTIL"))
-    nvlink_gbps = bytes_per_s_to_gbps(state.rates.get(NVLINK_TOTAL_METRIC))
+    nvlink_gbps = nvlink_to_gbps(state.values.get(NVLINK_TOTAL_METRIC))
     right.add_row("Memcpy", Text(fmt_pct(memcpy_pct), style=usage_style(memcpy_pct)))
     right.add_row("PCIe RX", Text(fmt_bytes_per_s(state.values.get("DCGM_FI_PROF_PCIE_RX_BYTES")), style="cyan"))
     right.add_row("PCIe TX", Text(fmt_bytes_per_s(state.values.get("DCGM_FI_PROF_PCIE_TX_BYTES")), style="cyan"))
@@ -2267,7 +2261,7 @@ def selected_gpu_panel(state: DerivedGPUState, history: HistoryStore, power_limi
     gpu = state.gpu_id
     title = f"Focused GPU {gpu}   {state.identity.get('device', '')}   {state.identity.get('pci_bus_id', '')}"
 
-    nvlink_gbps = bytes_per_s_to_gbps(state.rates.get(NVLINK_TOTAL_METRIC))
+    nvlink_gbps = nvlink_to_gbps(state.values.get(NVLINK_TOTAL_METRIC))
     nvlink_max = nvlink_limit or 400.0
 
     # Helper to read a profiling-level percent metric; returns None when absent.
@@ -2622,8 +2616,8 @@ Metrics and interpretation:
   DRAM           Fraction of cycles device memory is actively moving data.
   Memcpy         Device memory-copy engine utilization.
   PCIe RX/TX     Host-device throughput from dcgm-exporter in bytes/sec.
-  NVLink Δ       Per-second change from DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,
-                 shown as decimal GB/s.
+  NVLink Δ       Instantaneous NVLink bandwidth from DCGM field 449 (MB/s),
+                 converted to GB/s.
 
 Status classification (thresholds from NVIDIA DCGM profiling metric guidance):
 

--- a/kempner_pulse.py
+++ b/kempner_pulse.py
@@ -781,6 +781,11 @@ class DcgmStreamReader:
         self._skipped_first: bool = False
         self._error: Optional[BaseException] = None
         self._started = False
+        # dcgmi dmon reports field 449 (NVLINK_BANDWIDTH_TOTAL) as per-interval
+        # values, not as a cumulative counter (unlike fields 156 and 202 which
+        # ARE cumulative). Accumulate into a running total so downstream rate()
+        # sees a monotonically growing counter and computes bytes/s correctly.
+        self._nvlink_accum: Dict[str, float] = {}
 
     # ── lifecycle ───────────────────────────────────────────────────────
 
@@ -948,6 +953,13 @@ class DcgmStreamReader:
         # Reassemble block text in original order, then parse once
         block_text = "\n".join(current[gid] for gid in order)
         sample = parse_dcgm_dmon(block_text, self._gpu_models)
+        # Accumulate NVLINK_BANDWIDTH_TOTAL per-interval values into a running
+        # total so rate() sees a monotonic counter (see __init__ comment).
+        for gpu_id, metrics in sample.metrics.items():
+            raw = metrics.get(NVLINK_TOTAL_METRIC)
+            if raw is not None:
+                self._nvlink_accum[gpu_id] = self._nvlink_accum.get(gpu_id, 0.0) + raw
+                metrics[NVLINK_TOTAL_METRIC] = self._nvlink_accum[gpu_id]
         if not self._skipped_first:
             # Drop the first tick — profiling fields often N/A on cold dcgmi start
             self._skipped_first = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kempnerpulse"
-version = "0.4.0"
+version = "0.4.1"
 description = "Real-time GPU monitoring dashboard for DCGM Prometheus metrics"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kempnerpulse"
-version = "0.4.1"
+version = "0.4.0"
 description = "Real-time GPU monitoring dashboard for DCGM Prometheus metrics"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## Summary

- Fix NVLink bandwidth always showing `--` on **both backends** (`--backend dcgm` and `--backend prometheus`)
- `DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL` (field 449) is an **instantaneous rate in MB/s** on both `dcgmi dmon` and `dcgm-exporter` — not a cumulative counter despite dcgm-exporter labelling it as one
- Remove field 449 from `COUNTER_METRICS` (no more `rate()` applied)
- Remove the per-interval accumulation workaround from `DcgmStreamReader._publish()`
- Add `nvlink_to_gbps()` helper that reads raw MB/s from `state.values` and converts to GB/s
- All display and export sites now read `state.values` instead of `state.rates`

## Verified

Tested on 4× H200 under active FSDP:

**dcgm backend** (`--backend dcgm --poll 1`):
```
timestamp,gpu_id,nvlink_gbps
1776142573.50,0,201.7770
1776142573.50,1,200.4190
1776142573.50,2,203.8640
1776142573.50,3,205.2470
```

**prometheus backend** (`--poll 2`):
```
timestamp,gpu_id,nvlink_gbps
1776142613.73,0,111.3230
1776142613.73,1,127.0720
1776142613.73,2,126.8200
1776142613.73,3,127.1700
```

Cross-validated with `nvidia-smi nvlink -gt d` delta measurement: ~202 GB/s.

Closes #10