### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kempnerpulse"
-version = "0.4.0"
+version = "0.4.1"
 description = "Real-time GPU monitoring dashboard for DCGM Prometheus metrics"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## Summary

- Bump version from 0.4.0 to 0.4.1

## Changes in this release

- Fix NVLink bandwidth always blank on both backends (#10, PR #11)